### PR TITLE
Fixed two errant `runState` uses

### DIFF
--- a/src/Control/Monad/Freer.hs
+++ b/src/Control/Monad/Freer.hs
@@ -84,7 +84,7 @@ implemented in-memory in terms of 'Control.Monad.Freer.State.State'. With
 
 @
 runInMemoryFileSystem :: [('FilePath', 'String')] -> 'Eff' (FileSystem ': effs) '~>' 'Eff' effs
-runInMemoryFileSystem initVfs = 'Control.Monad.Freer.State.runState' initVfs '.' fsToState where
+runInMemoryFileSystem initVfs = 'Control.Monad.Freer.State.evalState' initVfs '.' fsToState where
   fsToState :: 'Eff' (FileSystem ': effs) '~>' 'Eff' ('Control.Monad.Freer.State.State' [('FilePath', 'String')] ': effs)
   fsToState = 'reinterpret' '$' \case
     ReadFile path -> 'Control.Monad.Freer.State.get' '>>=' \\vfs -> case 'lookup' path vfs of


### PR DESCRIPTION
In the tutorial and the readme you use `runState`, which returns `(a,s)` whereas what the rest of the code suggests is that you only want to return `a`, ergo `evalState` is needed.