### PR TITLE
Reverse Indexed Union

### DIFF
--- a/examples/src/Capitalize.hs
+++ b/examples/src/Capitalize.hs
@@ -6,7 +6,7 @@ module Capitalize
 
 import Data.Char (toUpper)
 
-import Control.Monad.Freer (Eff, Member, interpret, send)
+import Control.Monad.Freer (Eff, Member, HasLen, interpret, send)
 
 data Capitalize v where
   Capitalize :: String -> Capitalize String
@@ -14,5 +14,5 @@ data Capitalize v where
 capitalize :: Member Capitalize r => String -> Eff r String
 capitalize = send . Capitalize
 
-runCapitalize :: Eff (Capitalize ': r) w -> Eff r w
+runCapitalize :: HasLen r => Eff (Capitalize ': r) w -> Eff r w
 runCapitalize = interpret $ \(Capitalize s) -> pure (map toUpper s)

--- a/examples/src/Console.hs
+++ b/examples/src/Console.hs
@@ -12,7 +12,7 @@ module Console
 import Data.Function ((&))
 import System.Exit (exitSuccess)
 
-import Control.Monad.Freer (Eff, LastMember, Member, interpretM, reinterpret3, run, runM, send)
+import Control.Monad.Freer (Eff, LastMember, Member, HasLen, interpretM, reinterpret3, run, runM, send)
 import Control.Monad.Freer.Error (Error, runError, throwError)
 import Control.Monad.Freer.State (State, get, put, runState)
 import Control.Monad.Freer.Writer (Writer, runWriter, tell)
@@ -61,7 +61,7 @@ runConsolePure inputs req = snd . fst $
 -------------------------------------------------------------------------------
                      -- Effectful Interpreter for Deeper Stack --
 -------------------------------------------------------------------------------
-runConsoleM :: forall effs a. LastMember IO effs
+runConsoleM :: forall effs a. (LastMember IO effs, HasLen effs)
             => Eff (Console ': effs) a -> Eff effs a
 runConsoleM = interpretM $ \case
   PutStrLn msg -> putStrLn msg
@@ -73,7 +73,8 @@ runConsoleM = interpretM $ \case
 -------------------------------------------------------------------------------
 runConsolePureM
   :: forall effs w
-   . [String]
+   . HasLen effs
+  => [String]
   -> Eff (Console ': effs) w
   -> Eff effs (Maybe w, [String], [String])
 runConsolePureM inputs req = do

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ library:
   dependencies:
   - natural-transformation >= 0.2
   - transformers-base
+  - ghc-prim
 
 executables:
   freer-examples:

--- a/src/Control/Monad/Freer/Coroutine.hs
+++ b/src/Control/Monad/Freer/Coroutine.hs
@@ -22,7 +22,7 @@ module Control.Monad.Freer.Coroutine
   , replyC
   ) where
 
-import Control.Monad.Freer.Internal (Eff, Member, handleRelay, interpose, send)
+import Control.Monad.Freer.Internal (Eff, Member, HasLen, handleRelay, interpose, send)
 
 -- | A type representing a yielding of control.
 --
@@ -59,7 +59,7 @@ replyC
 replyC (Yield a k) arr = pure $ Continue a (arr . k)
 
 -- | Launch a coroutine and report its status.
-runC :: Eff (Yield a b ': effs) r -> Eff effs (Status effs a b r)
+runC :: HasLen effs => Eff (Yield a b ': effs) r -> Eff effs (Status effs a b r)
 runC = handleRelay (pure . Done) replyC
 
 -- | Launch a coroutine and report its status, without handling (removing)

--- a/src/Control/Monad/Freer/Fresh.hs
+++ b/src/Control/Monad/Freer/Fresh.hs
@@ -19,7 +19,7 @@ module Control.Monad.Freer.Fresh
   , evalFresh
   ) where
 
-import Control.Monad.Freer.Internal (Eff, Member, handleRelayS, send)
+import Control.Monad.Freer.Internal (Eff, Member, HasLen, handleRelayS, send)
 
 -- | Fresh effect model.
 data Fresh r where
@@ -31,11 +31,11 @@ fresh = send Fresh
 
 -- | Handler for 'Fresh' effects, with an 'Int' for a starting value. The
 -- return value includes the next fresh value.
-runFresh :: Int -> Eff (Fresh ': effs) a -> Eff effs (a, Int)
+runFresh :: HasLen effs => Int -> Eff (Fresh ': effs) a -> Eff effs (a, Int)
 runFresh s =
   handleRelayS s (\s' a -> pure (a, s')) (\s' Fresh k -> (k $! s' + 1) s')
 
 -- | Handler for 'Fresh' effects, with an 'Int' for a starting value. Discards
 -- the next fresh value.
-evalFresh :: Int -> Eff (Fresh ': effs) a -> Eff effs a
+evalFresh :: HasLen effs => Int -> Eff (Fresh ': effs) a -> Eff effs a
 evalFresh s = fmap fst . runFresh s

--- a/src/Control/Monad/Freer/Internal.hs
+++ b/src/Control/Monad/Freer/Internal.hs
@@ -213,7 +213,8 @@ runM (E u q) = case extract u of
 -- | Like 'replaceRelay', but with support for an explicit state to help
 -- implement the interpreter.
 replaceRelayS
-  :: s
+  :: HasLen effs
+  => s
   -> (s -> a -> Eff (v ': effs) w)
   -> (forall x. s -> t x -> (s -> Arr (v ': effs) x w) -> Eff (v ': effs) w)
   -> Eff (t ': effs) a
@@ -233,7 +234,8 @@ replaceRelayS s' pure' bind = loop s'
 -- defined in terms of other ones without leaking intermediary implementation
 -- details through the type signature.
 replaceRelay
-  :: (a -> Eff (v ': effs) w)
+  :: HasLen effs
+  => (a -> Eff (v ': effs) w)
   -> (forall x. t x -> Arr (v ': effs) x w -> Eff (v ': effs) w)
   -> Eff (t ': effs) a
   -> Eff (v ': effs) w
@@ -249,7 +251,7 @@ replaceRelay pure' bind = loop
 
 replaceRelayN
   :: forall gs t a effs w
-   . Weakens gs
+   . (Weakens gs, HasLen effs)
   => (a -> Eff (gs :++: effs) w)
   -> (forall x. t x -> Arr (gs :++: effs) x w -> Eff (gs :++: effs) w)
   -> Eff (t ': effs) a
@@ -268,7 +270,8 @@ replaceRelayN pure' bind = loop
 
 -- | Given a request, either handle it or relay it.
 handleRelay
-  :: (a -> Eff effs b)
+  :: HasLen effs
+  => (a -> Eff effs b)
   -- ^ Handle a pure value.
   -> (forall v. eff v -> Arr effs v b -> Eff effs b)
   -- ^ Handle a request for effect of type @eff :: * -> *@.
@@ -289,7 +292,8 @@ handleRelay ret h = loop
 -- @s :: *@ to be handled for the target effect, or relayed to a handler that
 -- can- handle the target effect.
 handleRelayS
-  :: s
+  :: HasLen effs
+  => s
   -> (s -> a -> Eff effs b)
   -- ^ Handle a pure value.
   -> (forall v. s -> eff v -> (s -> Arr effs v b) -> Eff effs b)

--- a/src/Control/Monad/Freer/NonDet.hs
+++ b/src/Control/Monad/Freer/NonDet.hs
@@ -20,6 +20,7 @@ import Control.Monad (msum)
 import Control.Monad.Freer.Internal
   ( Eff(..)
   , Member
+  , HasLen
   , NonDet(..)
   , handleRelay
   , prj
@@ -30,7 +31,7 @@ import Control.Monad.Freer.Internal
 
 -- | A handler for nondeterminstic effects.
 makeChoiceA
-  :: Alternative f
+  :: (Alternative f, HasLen effs)
   => Eff (NonDet ': effs) a
   -> Eff effs (f a)
 makeChoiceA = handleRelay (pure . pure) $ \m k ->

--- a/src/Control/Monad/Freer/Reader.hs
+++ b/src/Control/Monad/Freer/Reader.hs
@@ -30,7 +30,7 @@ module Control.Monad.Freer.Reader
     -- $localExample
   ) where
 
-import Control.Monad.Freer (Eff, Member, interpose, interpret, send)
+import Control.Monad.Freer (Eff, Member, HasLen, interpose, interpret, send)
 
 -- | Represents shared immutable environment of type @(e :: *)@ which is made
 -- available to effectful computation.
@@ -52,7 +52,7 @@ asks
 asks f = f <$> ask
 
 -- | Handler for 'Reader' effects.
-runReader :: forall r effs a. r -> Eff (Reader r ': effs) a -> Eff effs a
+runReader :: forall r effs a. HasLen effs => r -> Eff (Reader r ': effs) a -> Eff effs a
 runReader r = interpret (\Ask -> pure r)
 
 -- | Locally rebind the value in the dynamic environment.

--- a/src/Control/Monad/Freer/State.hs
+++ b/src/Control/Monad/Freer/State.hs
@@ -41,7 +41,7 @@ module Control.Monad.Freer.State
 
 import Data.Proxy (Proxy)
 
-import Control.Monad.Freer (Eff, Member, send)
+import Control.Monad.Freer (Eff, Member, HasLen, send)
 import Control.Monad.Freer.Internal (Arr, handleRelayS, interposeS)
 
 -- | Strict 'State' effects: one can either 'Get' values or 'Put' them.
@@ -68,17 +68,17 @@ gets :: forall s a effs. Member (State s) effs => (s -> a) -> Eff effs a
 gets f = f <$> get
 
 -- | Handler for 'State' effects.
-runState :: forall s effs a. s -> Eff (State s ': effs) a -> Eff effs (a, s)
+runState :: forall s effs a. HasLen effs => s -> Eff (State s ': effs) a -> Eff effs (a, s)
 runState s0 = handleRelayS s0 (\s x -> pure (x, s)) $ \s x k -> case x of
   Get -> k s s
   Put s' -> k s' ()
 
 -- | Run a 'State' effect, returning only the final state.
-execState :: forall s effs a. s -> Eff (State s ': effs) a -> Eff effs s
+execState :: forall s effs a. HasLen effs => s -> Eff (State s ': effs) a -> Eff effs s
 execState s = fmap snd . runState s
 
 -- | Run a State effect, discarding the final state.
-evalState :: forall s effs a. s -> Eff (State s ': effs) a -> Eff effs a
+evalState :: forall s effs a. HasLen effs => s -> Eff (State s ': effs) a -> Eff effs a
 evalState s = fmap fst . runState s
 
 -- | An encapsulated State handler, for transactional semantics. The global

--- a/src/Control/Monad/Freer/Writer.hs
+++ b/src/Control/Monad/Freer/Writer.hs
@@ -21,7 +21,7 @@ module Control.Monad.Freer.Writer
 import Control.Arrow (second)
 import Data.Monoid ((<>))
 
-import Control.Monad.Freer.Internal (Eff, Member, handleRelay, send)
+import Control.Monad.Freer.Internal (Eff, Member, HasLen, handleRelay, send)
 
 -- | Writer effects - send outputs to an effect environment.
 data Writer w r where
@@ -32,6 +32,6 @@ tell :: forall w effs. Member (Writer w) effs => w -> Eff effs ()
 tell w = send (Tell w)
 
 -- | Simple handler for 'Writer' effects.
-runWriter :: forall w effs a. Monoid w => Eff (Writer w ': effs) a -> Eff effs (a, w)
+runWriter :: forall w effs a. (HasLen effs, Monoid w) => Eff (Writer w ': effs) a -> Eff effs (a, w)
 runWriter = handleRelay (\a -> pure (a, mempty)) $ \(Tell w) k ->
   second (w <>) <$> k ()

--- a/src/Data/OpenUnion.hs
+++ b/src/Data/OpenUnion.hs
@@ -28,6 +28,7 @@ module Data.OpenUnion
   , Member(..)
   , Members
   , LastMember
+  , HasLen
   ) where
 
 import Data.Kind (Constraint)
@@ -40,6 +41,7 @@ import Data.OpenUnion.Internal
   , decomp
   , extract
   , weaken
+  , HasLen
   )
 
 -- | A shorthand constraint that represents a combination of multiple 'Member'

--- a/src/Data/OpenUnion/Internal.hs
+++ b/src/Data/OpenUnion/Internal.hs
@@ -33,7 +33,7 @@
 -- substitution for @Typeable@.
 module Data.OpenUnion.Internal where
 
-import GHC.TypeLits
+import GHC.TypeLits (TypeError, ErrorMessage(..))
 import Unsafe.Coerce (unsafeCoerce)
 
 -- | Open union is a strong sum (existential with an evidence).

--- a/tests/Tests/Exception.hs
+++ b/tests/Tests/Exception.hs
@@ -4,7 +4,7 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase, (@?=))
 import Test.Tasty.QuickCheck (testProperty)
 
-import Control.Monad.Freer (Eff, Member, Members, run)
+import Control.Monad.Freer (Eff, Member, Members, HasLen, run)
 import Control.Monad.Freer.Error (Error, catchError, runError, throwError)
 import Control.Monad.Freer.Reader (ask, runReader)
 import Control.Monad.Freer.State (State, get, put, runState)
@@ -75,7 +75,7 @@ ex2 m = do
     else pure v
 
 -- | Specialization to tell the type of the exception.
-runErrBig :: Eff (Error TooBig ': r) a -> Eff r (Either TooBig a)
+runErrBig :: HasLen r => Eff (Error TooBig ': r) a -> Eff r (Either TooBig a)
 runErrBig = runError
 
 ex2rr :: Either TooBig Int

--- a/tests/Tests/Fresh.hs
+++ b/tests/Tests/Fresh.hs
@@ -6,7 +6,7 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit ((@?=), testCase)
 import Test.Tasty.QuickCheck ((==>), testProperty)
 
-import Control.Monad.Freer (Eff, run)
+import Control.Monad.Freer (Eff, HasLen, run)
 import Control.Monad.Freer.Fresh (fresh, runFresh)
 
 tests :: TestTree
@@ -17,7 +17,7 @@ tests = testGroup "Fresh tests"
       $ \n -> n > 0 ==> testFresh n == (n-1)
   ]
 
-makeFresh :: Int -> Eff r Int
+makeFresh :: HasLen r => Int -> Eff r Int
 makeFresh n = fst <$> runFresh 0 (last <$> replicateM n fresh)
 
 testFresh :: Int -> Int


### PR DESCRIPTION
This PR implements the open union by indexing the type from the tail end of the list. My thinking was that this way `decomp` and `weaken` does not need to do any index modification or allocation and can simply `unsafeCoerce`. 

Basically I liked the idea of a "stable index".

The unfortunate consequence is that `decomp` along with any function using it gets an additional `HasLen` constraint. I implemented it at first using type level literals and a type level computation `Len` for type level lists, but this would have meant carrying a `KnownNat (Len effs)` constraint and furthermore it does not play nicely with partial lists, as the constraint does not carry through the type level computation, resulting in errors like `could not deduce KnownNat (1 + Len effs) from a constraint KnwonNat (Len effs)` etc.

Anyhow, this implementation works and passes the test suite. It does however run roughly twice as long 😞. It seems reallocating the union and decementing a `Word` value is cheaper than an additional, inlineable, compile time constant dict ... 

As a result of the performance implications and the interface change *I fully expect this PR to be rejected*, but I figured I'd open it anyways, since I'd already done the work. Perhaps it'd make sense to park this in a branch somewhere, maybe Iit'll be of use some time in the future, who knows.