### PR TITLE
Generalize makeEffect to work with more complicated GADTs

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: freer-simple
-version: 1.2.0.0
+version: 1.2.1.0
 category: Control
 synopsis: Implementation of a friendly effect system for Haskell.
 description: |

--- a/tests/Tests/TH.hs
+++ b/tests/Tests/TH.hs
@@ -32,3 +32,20 @@ runPrepender = interpret
 
 testGeneratedFunction :: String -> String
 testGeneratedFunction s = run . runPrepender $ prependSomething s
+
+-- Create a more complicated test GADT
+data Complicated a where
+  Mono :: Int -> Complicated Bool
+  Poly :: a -> Complicated a
+  PolyIn :: a -> Complicated Bool
+  PolyOut :: Int -> Complicated a
+  Lots :: a -> b -> c -> d -> e -> f -> Complicated ()
+  Nested :: Maybe b -> Complicated (Maybe a)
+  MultiNested :: (Maybe a, [b]) -> Complicated (Maybe a, [b])
+  Existential :: (forall e. e -> Maybe e) -> Complicated a
+  LotsNested :: Maybe a -> [b] -> (c, c) -> Complicated (a, b, c)
+  Dict :: (Ord a) => a -> Complicated a
+  MultiDict :: (Eq a, Ord b, Enum a, Num c) => a -> b -> c -> Complicated ()
+
+-- Make TH generate our effect functions.
+makeEffect ''Complicated


### PR DESCRIPTION
closes https://github.com/lexi-lambda/freer-simple/issues/16

Instead of descending down into the types in the constructor looking for free variables (I have a branch that does this) I think it is cleaner to simply reuse the preexisting contexts from the GADT constructor. Thus, if the variable quantification and contexts were correct in the constructor, they should still be correct for the generator function (I think).

I bumped the version, but I don't know if I bumped the right number.