### PR TITLE
Allow template-haskell 2.17, 2.18

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -57,7 +57,7 @@ library:
   dependencies:
   - natural-transformation >= 0.2
   - transformers-base
-  - template-haskell >= 2.11 && < 2.17
+  - template-haskell >= 2.11 && < 2.18
 
 executables:
   freer-examples:

--- a/package.yaml
+++ b/package.yaml
@@ -57,7 +57,7 @@ library:
   dependencies:
   - natural-transformation >= 0.2
   - transformers-base
-  - template-haskell >= 2.11 && < 2.18
+  - template-haskell >= 2.11 && < 2.19
 
 executables:
   freer-examples:


### PR DESCRIPTION
With a bit of CPP for backwards compatibility.

Ref https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.0#template-haskell-217