### PR TITLE
Use lenses to permit "focusing" on a State effect

### DIFF
--- a/freer-simple.cabal
+++ b/freer-simple.cabal
@@ -85,6 +85,7 @@ library
     , natural-transformation >= 0.2
     , transformers-base
     , template-haskell >= 2.11 && < 2.19
+    , lens
 
 executable freer-simple-examples
   import: common


### PR DESCRIPTION
A draft PR to show the concept....

One of the great things about algebraic effects is that they allow you to _focus_ the range of effects needed by a function to its most limited set: the "weakest precondition of effects", if you will.

This PR shows a simple way to make this idea more flexible. For example, I often have an "application state" carried by an effect `State s`, but many of my functions need only a part of this state, or they may need those parts only in read-only or append-only terms. It could be that I have a huge state, and my function needs read-only access to one part and read-write access to another part, but none of the rest.

The current `freer-simple` library already makes this fairly easy to do, but users have to write the reinterpretations themselves. This PR offers a few combinators for lensing into state in these different ways.

I doubt you'd want to include `lens` as a dependency, but if you think it's useful maybe it could become its own library. I also want to see how this idea plays out in other libraries like `fused-effects`.