### PR TITLE
Widen template-haskell version constraint to allow version <2.22

### DIFF
--- a/freer-simple.cabal
+++ b/freer-simple.cabal
@@ -84,7 +84,7 @@ library
   build-depends:
     , natural-transformation >= 0.2
     , transformers-base
-    , template-haskell >= 2.11 && < 2.19
+    , template-haskell >= 2.11 && < 2.22
 
 executable freer-simple-examples
   import: common


### PR DESCRIPTION
This allows freer-simple to be used with GHC >= 9.4. Prior versions of template-haskell are not compatible with those GHC versions. Newer version of of template-haskell seem to be fully compatible with freer-simple. That is, tests still pass and I haven't noticed any issues in my own project (which use freer-simple).

Fixes #40

---

If this gets merged, would it be possible to tag a new freer-simple release?