### PR TITLE
Support GHC 9.10 and above

### DIFF
--- a/freer-simple.cabal
+++ b/freer-simple.cabal
@@ -84,7 +84,7 @@ library
   build-depends:
     , natural-transformation >= 0.2
     , transformers-base
-    , template-haskell >= 2.11 && < 2.19
+    , template-haskell >= 2.11 && < 2.22
 
 executable freer-simple-examples
   import: common

--- a/freer-simple.cabal
+++ b/freer-simple.cabal
@@ -84,7 +84,7 @@ library
   build-depends:
     , natural-transformation >= 0.2
     , transformers-base
-    , template-haskell >= 2.11 && < 2.22
+    , template-haskell >= 2.11 && < 2.23
 
 executable freer-simple-examples
   import: common

--- a/freer-simple.cabal
+++ b/freer-simple.cabal
@@ -84,7 +84,7 @@ library
   build-depends:
     , natural-transformation >= 0.2
     , transformers-base
-    , template-haskell >= 2.11 && < 2.23
+    , template-haskell >= 2.11 && < 2.24
 
 executable freer-simple-examples
   import: common

--- a/src/Control/Monad/Freer/Internal.hs
+++ b/src/Control/Monad/Freer/Internal.hs
@@ -153,7 +153,7 @@ instance Monad (Eff effs) where
   E u q >>= k = E u (q |> k)
   {-# INLINE (>>=) #-}
 
-instance (MonadBase b m, LastMember m effs) => MonadBase b (Eff effs) where
+instance (Monad b, MonadBase b m, LastMember m effs) => MonadBase b (Eff effs) where
   liftBase = sendM . liftBase
   {-# INLINE liftBase #-}
 


### PR DESCRIPTION
Based on top of https://github.com/lexi-lambda/freer-simple/pull/44.

Of course, to prevent build errors, there also really ought to be Hackage revisions on older versions of `freer-simple` to specify that they are only compatible with `base < 4.20`. 